### PR TITLE
Changed docker-compose template

### DIFF
--- a/.stubs/compose/_laravel.stub
+++ b/.stubs/compose/_laravel.stub
@@ -2,10 +2,10 @@ version: "3.8"
 
 services:
   php:
-    image: dunglas/frankenphp
-    container_name: $DIR-app
-    # uncomment the following line if you want to use a custom Dockerfile
-    #build: .
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    image: $DIR-app #name of the image
     # uncomment the following line if you want to run this in a production environment
     # restart: always
     ports:

--- a/.stubs/devcontainer/_laravel.stub
+++ b/.stubs/devcontainer/_laravel.stub
@@ -1,10 +1,11 @@
 {
     "name": "$DIR",
     "service": "php",
-    "workspaceFolder": "/workspaces/LOCAL_WORKSPACE_FOLDER_BASENAME",
+    "workspaceFolder": "/app",
     "dockerComposeFile": [
         "docker-compose.yml"
     ],
+    "postCreateCommand": "nvm install --lts",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.stubs/devcontainer/_laravel.stub
+++ b/.stubs/devcontainer/_laravel.stub
@@ -5,7 +5,7 @@
     "dockerComposeFile": [
         "docker-compose.yml"
     ],
-    "postCreateCommand": "nvm install --lts",
+    "postCreateCommand": "bash -c 'nvm install --lts'",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.stubs/dockerfile/_laravel.stub
+++ b/.stubs/dockerfile/_laravel.stub
@@ -1,0 +1,20 @@
+FROM dunglas/frankenphp
+
+# add additional extensions here:
+RUN install-php-extensions \
+    pdo_mysql \
+    gd \
+    intl \
+    zip \
+    opcache
+
+#install composer
+RUN curl -sS https://getcomposer.org/installer -o composer-setup.php
+RUN php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+RUN rm -rf composer-setup.php
+
+# Install Node.js using NVM
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+
+# Changing Workdir
+WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 My personal bash file to create .devcontainer projects, based on my daily use of Docker.
 
+## Prerequisites
+Have [Gum](https://github.com/charmbracelet/gum) installed
+
+## Notes
+This is a personal script, so its only tested on Linux, can't really check if it works on mac...
+
 ## How to use?
 Clone and copy `vwizard` to `/usr/local/bin`
 
@@ -23,5 +29,3 @@ sudo chmod +x /usr/local/bin/vwizard
 
 That should do it, you can call it from anywhere by calling `vwizard
 
-## Prerequisites
-Have [Gum](https://github.com/charmbracelet/gum) installed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Give execute permission to `vwizard`
 sudo chmod +x /usr/local/bin/vwizard
 ```
 
-That should do it, you can call it from anywhere by calling `vwizard`
+That should do it, you can call it from anywhere by calling `vwizard
 
 ## Prerequisites
 Have [Gum](https://github.com/charmbracelet/gum) installed

--- a/vwizard
+++ b/vwizard
@@ -87,8 +87,8 @@ create_compose_dev_container(){
     envsubst < "$STUBS_DIR/devcontainer/_laravel.stub" > "$DIR/.devcontainer/devcontainer.json"
 
     
-
-    sed -i 's/LOCAL_WORKSPACE_FOLDER_BASENAME/${localWorkspaceFolderBasename}/g' "$devcontainer_dir/devcontainer.json"
+    #No longer needed because frankenPHP always looks for /app folder
+    #sed -i 's/LOCAL_WORKSPACE_FOLDER_BASENAME/${localWorkspaceFolderBasename}/g' "$devcontainer_dir/devcontainer.json"
 
     # Create a default docker-compose.yml file
     touch "$devcontainer_dir/Dockerfile" #for now empty

--- a/vwizard
+++ b/vwizard
@@ -106,6 +106,7 @@ compose_file(){
 
 # Replace the docker-compose.yml file with the one for laravel
 laravel_compose_file(){
+    envsubst < "$2/dockerfile/_laravel.stub" > "$1/Dockerfile"
     envsubst < "$2/compose/_laravel.stub" > "$1/docker-compose.yml"
 }
 


### PR DESCRIPTION
Change the docker-compose template to reference the Dockerfile build, in order to add missing extensions and composer for package installs